### PR TITLE
fix: use BigInt instead of number of token values

### DIFF
--- a/src/marketplace/marketplace.test.ts
+++ b/src/marketplace/marketplace.test.ts
@@ -33,16 +33,16 @@ describe("marketplace", async () => {
     describe("create", async () => {
       it("verifies that the availability was created successfully", async () => {
         assert.ok(availability.id);
-        assert.strictEqual(availability.duration, duration);
-        assert.strictEqual(availability.freeSize, totalSize);
-        assert.strictEqual(
+        assert.equal(availability.duration, duration);
+        assert.equal(availability.freeSize, totalSize);
+        assert.equal(
           availability.minPricePerBytePerSecond,
-          minPricePerBytePerSecond
+          BigInt(minPricePerBytePerSecond)
         );
-        assert.strictEqual(availability.totalCollateral, totalCollateral);
-        assert.strictEqual(
+        assert.equal(availability.totalCollateral, BigInt(totalCollateral));
+        assert.equal(
           availability.totalRemainingCollateral,
-          totalCollateral
+          BigInt(totalCollateral)
         );
         assert.strictEqual(availability.totalSize, totalSize);
         assert.strictEqual(availability.until, 0);
@@ -52,8 +52,8 @@ describe("marketplace", async () => {
       const errors: Partial<CodexCreateAvailabilityInput>[] = [
         { duration: 0 },
         { totalSize: 0 },
-        { totalCollateral: -1 },
-        { minPricePerBytePerSecond: -1 },
+        { totalCollateral: BigInt(-1) },
+        { minPricePerBytePerSecond: BigInt(-1) },
       ];
 
       for (const err of errors) {
@@ -90,9 +90,9 @@ describe("marketplace", async () => {
       const updates: Omit<CodexAvailabilityPatchInput, "id">[] = [
         { enabled: false },
         { duration: 3000 },
-        { minPricePerBytePerSecond: 1 },
+        { minPricePerBytePerSecond: BigInt(1) },
         { totalSize: 3000 },
-        { totalCollateral: 3000 },
+        { totalCollateral: BigInt(3000) },
         { until: 5000 },
       ];
 

--- a/src/marketplace/marketplace.test.ts
+++ b/src/marketplace/marketplace.test.ts
@@ -52,15 +52,15 @@ describe("marketplace", async () => {
       const errors: Partial<CodexCreateAvailabilityInput>[] = [
         { duration: 0 },
         { totalSize: 0 },
-        { totalCollateral: BigInt(-1) },
-        { minPricePerBytePerSecond: BigInt(-1) },
+        { totalCollateral: -1 },
+        { minPricePerBytePerSecond: -1 },
       ];
 
       for (const err of errors) {
         const field = Object.keys(err)[0] as keyof typeof err;
         assert.ok(field);
 
-        it(`fails to create availability with wrong ${field}`, async () => {
+        it(`fails to create availability with wrong ${field} = ${err[field]}`, async () => {
           const response = await spMarketplace.createAvailability({
             ...body,
             [field]: err[field],
@@ -73,9 +73,7 @@ describe("marketplace", async () => {
             response.data.errors[0]?.received,
             err[field]?.toString()
           );
-          assert.ok(
-            response.data.errors[0]?.message.startsWith("Invalid value:")
-          );
+          assert.ok(response.data.errors[0]?.message.startsWith("Invalid"));
         });
       }
     });
@@ -137,9 +135,7 @@ describe("marketplace", async () => {
             response.data.errors[0]?.received,
             err[field]?.toString()
           );
-          assert.ok(
-            response.data.errors[0]?.message.startsWith("Invalid value:")
-          );
+          assert.ok(response.data.errors[0]?.message.startsWith("Invalid"));
         });
       }
     });

--- a/src/marketplace/marketplace.ts
+++ b/src/marketplace/marketplace.ts
@@ -78,9 +78,9 @@ export class CodexMarketplace {
   }: CodexAvailabilityWithoutTypes) {
     const availability: CodexAvailability = {
       ...a,
-      minPricePerBytePerSecond: parseInt(a.minPricePerBytePerSecond, 10),
-      totalCollateral: parseInt(a.totalCollateral, 10),
-      totalRemainingCollateral: parseInt(a.totalRemainingCollateral, 10),
+      minPricePerBytePerSecond: BigInt(a.minPricePerBytePerSecond),
+      totalCollateral: BigInt(a.totalCollateral),
+      totalRemainingCollateral: BigInt(a.totalRemainingCollateral),
     };
 
     if (freeSize) {

--- a/src/marketplace/types.ts
+++ b/src/marketplace/types.ts
@@ -42,7 +42,7 @@ export const CodexCreateAvailabilityInput = v.strictObject({
   totalSize: v.pipe(v.number(), v.minValue(1)),
   duration: v.pipe(v.number(), v.minValue(1)),
   minPricePerBytePerSecond: v.union([
-    v.bigint(),
+    v.pipe(v.bigint(), v.minValue(BigInt(0))),
     v.pipe(
       v.number(),
       v.minValue(0),
@@ -50,7 +50,7 @@ export const CodexCreateAvailabilityInput = v.strictObject({
     ),
   ]),
   totalCollateral: v.union([
-    v.bigint(),
+    v.pipe(v.bigint(), v.minValue(BigInt(0))),
     v.pipe(
       v.number(),
       v.minValue(0),
@@ -85,17 +85,17 @@ export const CodexAvailabilityPatchInput = v.strictObject({
   duration: v.optional(v.pipe(v.number(), v.minValue(1))),
   minPricePerBytePerSecond: v.optional(
     v.union([
-      v.bigint(),
+      v.pipe(v.bigint(), v.minValue(BigInt(0))),
       v.pipe(
         v.number(),
-        v.minValue(1),
+        v.minValue(0),
         v.transform((input) => BigInt(input))
       ),
     ])
   ),
   totalCollateral: v.optional(
     v.union([
-      v.bigint(),
+      v.pipe(v.bigint(), v.minValue(BigInt(0))),
       v.pipe(
         v.number(),
         v.minValue(0),

--- a/src/marketplace/types.ts
+++ b/src/marketplace/types.ts
@@ -20,18 +20,14 @@ export type CodexAvailabilityWithoutTypes =
 export type CodexAvailability = Omit<
   CodexAvailabilityWithoutTypes,
   | "freeSize"
-  | "totalSize"
   | "minPricePerBytePerSecond"
-  | "duration"
   | "totalCollateral"
   | "totalRemainingCollateral"
 > & {
   freeSize?: number;
-  totalSize: number;
-  duration: number;
-  minPricePerBytePerSecond: number;
-  totalCollateral: number;
-  totalRemainingCollateral: number;
+  minPricePerBytePerSecond: BigInt;
+  totalCollateral: BigInt;
+  totalRemainingCollateral: BigInt;
 };
 
 export type CodexAvailabilityCreateResponse =
@@ -45,8 +41,22 @@ export type CodexAvailabilityCreateBody = Exclude<
 export const CodexCreateAvailabilityInput = v.strictObject({
   totalSize: v.pipe(v.number(), v.minValue(1)),
   duration: v.pipe(v.number(), v.minValue(1)),
-  minPricePerBytePerSecond: v.pipe(v.number(), v.minValue(0)),
-  totalCollateral: v.pipe(v.number(), v.minValue(0)),
+  minPricePerBytePerSecond: v.union([
+    v.bigint(),
+    v.pipe(
+      v.number(),
+      v.minValue(0),
+      v.transform((input) => BigInt(input))
+    ),
+  ]),
+  totalCollateral: v.union([
+    v.bigint(),
+    v.pipe(
+      v.number(),
+      v.minValue(0),
+      v.transform((input) => BigInt(input))
+    ),
+  ]),
   enabled: v.optional(v.boolean()),
   until: v.optional(v.pipe(v.number(), v.minValue(0))),
 });
@@ -61,23 +71,49 @@ export type CodexAvailabilityPatchBody = Partial<
   >["content"]["application/json"]
 >;
 
-export type CodexCreateAvailabilityInput = v.InferOutput<
-  typeof CodexCreateAvailabilityInput
->;
+export type CodexCreateAvailabilityInput = Omit<
+  v.InferOutput<typeof CodexCreateAvailabilityInput>,
+  "minPricePerBytePerSecond" | "totalCollateral"
+> & {
+  minPricePerBytePerSecond?: number | BigInt;
+  totalCollateral?: number | BigInt;
+};
 
 export const CodexAvailabilityPatchInput = v.strictObject({
   id: v.string(),
   totalSize: v.optional(v.pipe(v.number(), v.minValue(1))),
   duration: v.optional(v.pipe(v.number(), v.minValue(1))),
-  minPricePerBytePerSecond: v.optional(v.pipe(v.number(), v.minValue(1))),
-  totalCollateral: v.optional(v.pipe(v.number(), v.minValue(0))),
+  minPricePerBytePerSecond: v.optional(
+    v.union([
+      v.bigint(),
+      v.pipe(
+        v.number(),
+        v.minValue(1),
+        v.transform((input) => BigInt(input))
+      ),
+    ])
+  ),
+  totalCollateral: v.optional(
+    v.union([
+      v.bigint(),
+      v.pipe(
+        v.number(),
+        v.minValue(0),
+        v.transform((input) => BigInt(input))
+      ),
+    ])
+  ),
   enabled: v.optional(v.boolean()),
   until: v.optional(v.pipe(v.number(), v.minValue(0))),
 });
 
-export type CodexAvailabilityPatchInput = v.InferOutput<
-  typeof CodexAvailabilityPatchInput
->;
+export type CodexAvailabilityPatchInput = Omit<
+  v.InferOutput<typeof CodexAvailabilityPatchInput>,
+  "minPricePerBytePerSecond" | "totalCollateral"
+> & {
+  minPricePerBytePerSecond?: number | BigInt;
+  totalCollateral?: number | BigInt;
+};
 
 export type CodexReservationsResponse =
   paths["/sales/availability/{id}/reservations"]["get"]["responses"][200]["content"]["application/json"];

--- a/src/node/node.ts
+++ b/src/node/node.ts
@@ -57,7 +57,7 @@ export class CodexNode {
   ): Promise<SafeValue<CodexSpr<CodexSprContentType>>> {
     const url = this.url + Api.config.prefix + "/spr";
 
-    if (type === "json") {
+    if (type == "json") {
       return Fetch.safeJson<CodexSprJsonResponse>(url, {
         method: "GET",
         headers: {
@@ -84,7 +84,7 @@ export class CodexNode {
   ): Promise<SafeValue<CodexPeerId<CodexPeerIdContentType>>> {
     const url = this.url + Api.config.prefix + "/node/peerid";
 
-    if (type === "json") {
+    if (type == "json") {
       return Fetch.safeJson<CodexPeerIdJsonResponse>(url, {
         method: "GET",
         headers: {


### PR DESCRIPTION
This PR uses BigInt instead of number of token values to avoid overflow value.